### PR TITLE
DOC: drop `astral` badge(s) and url(s) from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![PyPI](https://img.shields.io/pypi/v/cblind)](https://pypi.org/project/cblind/)
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/cblind)](https://pypi.org/project/cblind/)
 [![Documentation Status](https://readthedocs.org/projects/cblind/badge/?version=latest)](https://cblind.readthedocs.io/en/latest/?badge=latest)
-[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 
 A colorblind-friendly python module that allows color choice for plotting multiple curves
 8 colormaps are now available to map 2D fields


### PR DESCRIPTION
Following [the announcement](https://astral.sh/blog/openai) that astral was going to be aquired by OpenAI, I don't want to advertise their tools any longer.
I'm also considering migrating to `pixi` if/when uv stops being trustworthy.